### PR TITLE
close #81 | add viewport meta tag in documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=yes">
     <title>Rapido</title>
     <meta name="description" content="Rapido: create web documents with the only use of HTML snippets.">
     <meta name="robots" content="index,follow">
@@ -70,6 +70,7 @@
   &lt;html&gt;
     &lt;head&gt;
       &lt;meta charset="utf-8"&gt;
+      &lt;meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=yes"&gt;
       &lt;link href="rapido.css" rel="stylesheet" type="text/css"&gt;
     &lt;/head&gt;
     &lt;body class="rapido"&gt;


### PR DESCRIPTION
Explicitly let the user be able to zoom in/out the webpage.