### PR TITLE
close #63 | add footnotes

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,7 +472,7 @@
           </figure>
           <h2>Example 2</h2>
           <p>Having your formula in a new line is easy as well, just use <code>$$...$$</code> instead of <code>$...$</code>.</p>
-          <p>$$G_{\mu\nu} + \Lambda g_{\mu\nu} = \frac{8\pi G}{c^4}T_{\mu\nu}$$<small>Einstein field equations, expressed for the first time 8 years later the <q cite="https://isbnsearch.org/isbn/0192806726">the happiest thought of my life</q>.</small></p>
+          <p>$$G_{\mu\nu} + \Lambda g_{\mu\nu} = \frac{8\pi G}{c^4}T_{\mu\nu}$$<small>Einstein field equations <cite><a href="#ref-1">[1]</a></cite>, expressed for the first time 8 years later the <q cite="https://isbnsearch.org/isbn/0192806726">the happiest thought of my life</q> <cite><a href="#ref-2">[2]</a></cite>.</small></p>
           <figure>
             <pre><code>&lt;p&gt;
   ...
@@ -492,10 +492,10 @@
               \end{array}$$
             </p>
             <figcaption>
-              <h1>Maxwell's equations in vacuum</h1>
+              <h1>Maxwell's equations in vacuum.</h1>
               <p>The equations can be reduced to the standard wave equation $$
                 \frac{1}{c^2} \frac{\partial^2 \mathbf{F}}{\partial^2 t} - \nabla^2 \mathbf{F} = 0
-              $$ providing the theoretical background for the electromagnetic waves.</p>
+              $$ providing the theoretical background for the electromagnetic waves <cite><a href="#ref-3">[3]</a></cite>.</p>
             </figcaption>
           </figure>
           <figure>
@@ -514,6 +514,50 @@
             </figcaption>
           </figure>
         </section>
+        <footer>
+          <section>
+            <h1>Footnotes</h1>
+            <p>At the end of the article, you may want to add further information, like additional resources, footnotes, acknowledgements, author contribution, references, updates, corrections and so on. Rapido provides style rules for <strong>headings</strong>, <strong>paragraphs</strong>, <strong>lists</strong> and <strong>code snippets</strong> in the article footer.</p>
+            <pre><code>&lt;article&gt;
+  ...</code>
+<mark><code>  &lt;footer&gt;
+    &lt;section&gt;
+      &lt;h1&gt;...&lt;/h1&gt;
+      &lt;p&gt;...&lt;/p&gt;
+    &lt;/section&gt;
+    &lt;section&gt;
+      ...
+    &lt;/section&gt;
+  &lt;/footer&gt;</code></mark>
+<code>&lt;/article&gt;</code></pre>
+            <p>Code listings use the <code>&lt;pre&gt;</code> element and they may be wrapped or not within the <code>&lt;figure&gt;</code> element. Wrap code listings within the <code>&lt;figure&gt;</code> element if you want to add a caption.</p>
+          </section>
+          <section>
+            <h1>References</h1>
+            <ol>
+              <li id="ref-1">
+                <b>Gravitation.</b>
+                Charles W. Misner, Kip S. Thorne, John Archibald Wheeler. October 2017, Princeton University Press. ISBN-13: 9780691177793.
+              </li>
+              <li id="ref-2">
+                <b>Subtle Is the Lord: The Science and the Life of Albert Einstein.</b>
+                Abraham Pais. November 2005, Oxford University Press. ISBN-13: 9780192806727.
+              </li>
+              <li id="ref-3">
+                <b>Classical Electrodynamics.</b>
+                John David Jackson. Third Edition, August 1998, Wiley. ISBN-13: 9780471309321.
+              </li>
+            </ol>
+          </section>
+          <section>
+            <h1>Updates and Corrections</h1>
+            <p>If you see mistakes or want to suggest changes, please <a href="https://github.com/nextbitlabs/Rapido/issues">open an issue on GitHub</a>.</p>
+          </section>
+          <section>
+            <h1>Acknowledgements</h1>
+            <p>Rapido is an open source project sponsored by <a href="https://nextbit.it/">Nextbit</a>, we are glad of the support.</p>
+          </section>
+        </footer>
       </article>
     </main>
   </body>

--- a/rapido.css
+++ b/rapido.css
@@ -72,6 +72,16 @@ article.rapido > header {
 
 /* end header */
 
+/* footer */
+
+article.rapido > footer {
+	border-top: 1px solid #dedede;
+	padding: 10px 0 20px 0;
+	opacity: 0.7;
+}
+
+/* end footer */
+
 /* h1 */
 
 .rapido section > h1 {
@@ -90,6 +100,26 @@ article.rapido > header > h1 {
 	font-weight: bold;
 }
 
+article.rapido > footer h1 {
+	font-size: 12px;
+	line-height: 18px;
+	text-transform: uppercase;
+	margin: 0 0 10px 0;
+}
+
+article.rapido > footer > h1 {
+	margin: 20px 0 10px 0;
+}
+
+@media (min-width: 1024px) {
+	article.rapido > footer > section > h1 {
+		margin: 0;
+		max-width: 200px;
+		position: absolute;
+		padding-right: 20px;
+	}
+}
+
 .rapido section figcaption > h1,
 article.rapido > header > figure > figcaption > h1 {
 	display: inline;
@@ -97,6 +127,15 @@ article.rapido > header > figure > figcaption > h1 {
 	font-size: 14px;
 	line-height: 21px;
 	font-weight: bold;
+}
+
+article.rapido > footer figure > figcaption > h1 {
+	display: inline;
+	font-size: 12px;
+	line-height: 18px;
+	padding: 0;
+	font-weight: bold;
+	text-transform: unset;
 }
 
 @media (max-width: 1023px) {
@@ -131,6 +170,21 @@ article.rapido > header > figure > figcaption > h1 {
 	font-weight: bold;
 }
 
+article.rapido > footer > h2,
+article.rapido > footer > section > h2 {
+	max-width: unset;
+	margin: 0 0 10px 0;
+	font-size: 12px;
+	line-height: 18px;
+}
+
+@media (min-width: 1024px) {
+	article.rapido > footer > section > h2 {
+		max-width: calc(100% - 200px);
+		margin-left: 200px;
+	}
+}
+
 /* end h2 */
 
 /* section */
@@ -138,6 +192,16 @@ article.rapido > header > figure > figcaption > h1 {
 .rapido section {
 	width: 100%;
 	padding: 10px 0;
+}
+
+article.rapido > footer > section {
+	padding: 10px 0;
+}
+
+@media (min-width: 1024px) {
+	article.rapido > footer > section {
+		padding: 20px 0;
+	}
 }
 
 /* end section */
@@ -190,7 +254,8 @@ article.rapido > header > figure > figcaption > h1 {
 	}
 }
 
-article.rapido > header > figure > figcaption {
+article.rapido > header > figure > figcaption,
+article.rapido > footer > section > figure > figcaption {
 	width: 100%;
 	margin: 5px 0 0 0;
 }
@@ -206,6 +271,16 @@ article.rapido > header > figure > figcaption {
 	margin: 20px 0 20px 0;
 }
 
+article.rapido > footer figure {
+	margin: 10px 0;
+}
+
+@media (min-width: 1024px) {
+	article.rapido > footer > section > figure {
+		margin: 10px 0 10px 200px;
+	}
+}
+
 /* end figure */
 
 /* li */
@@ -213,6 +288,13 @@ article.rapido > header > figure > figcaption {
 .rapido li {
 	font-size: 14px;
 	line-height: 21px;
+}
+
+article.rapido > footer li {
+	width: 100%;
+	font-size: 12px;
+	line-height: 18px;
+	margin-bottom: 10px;
 }
 
 /* end li */
@@ -233,6 +315,25 @@ article.rapido > header > figure > figcaption {
 
 .rapido ol {
 	list-style-type: decimal;
+}
+
+article.rapido > footer ul,
+article.rapido > footer ol {
+	margin: 0;
+}
+
+article.rapido > footer > ul,
+article.rapido > footer > ol {
+	max-width: unset;
+}
+
+@media (min-width: 1024px) {
+	article.rapido > footer > section > ol,
+	article.rapido > footer > section > ul {
+		margin: 0 0 10px 200px;
+		width: calc(100% - 200px);
+		max-width: unset;
+	}
 }
 
 /* end ol, ul */
@@ -291,10 +392,25 @@ article.rapido > header > p {
 	line-height: 45px;
 }
 
-.rapido > header > figure > figcaption > p {
+article.rapido > footer p {
+	font-size: 12px;
+	line-height: 18px;
+	max-width: unset;
+	margin: 0 0 10px 0;
+}
+
+@media (min-width: 1024px) {
+	article.rapido > footer > section > p {
+		margin: 0 0 10px 200px;
+	}
+}
+
+article.rapido > footer figcaption > p {
+	padding: 0;
+}
+
+article.rapido > footer li > p {
 	display: inline;
-	font-size: 14px;
-	line-height: 21px;
 }
 
 @media (max-width: 499px) {
@@ -328,6 +444,28 @@ article.rapido > header > p {
 	line-height: 21px;
 }
 
+article.rapido > footer pre {
+	margin: 10px 0;
+}
+
+article.rapido > footer pre,
+article.rapido > footer figure > pre {
+	width: 100%;
+	font-size: 12px;
+	line-height: 18px;
+}
+
+article.rapido > footer figure > pre {
+	margin: 0;
+}
+
+@media (min-width: 1024px) {
+	article.rapido > footer > section > pre {
+		margin: 10px 0 10px 200px;
+		width: calc(100% - 200px);
+	}
+}
+
 /* end pre */
 
 /* a */
@@ -339,6 +477,10 @@ article.rapido > header > p {
 	text-decoration: underline;
 }
 
+.rapido cite > a {
+	text-decoration: none;
+}
+
 article.rapido > header > address > a {
 	margin: 5px 15px 5px 0;
 }
@@ -346,6 +488,10 @@ article.rapido > header > address > a {
 /* end a */
 
 /* cite */
+
+.rapido cite {
+	font-style: normal;
+}
 
 .rapido section > cite {
 	display: block;
@@ -377,12 +523,21 @@ article.rapido > header > address > a {
 	padding: 0 10px;
 }
 
+article.rapido > footer code {
+	color: #353830;
+}
+
 .rapido pre > mark > code {
 	display: inline-block;
 	min-width: 100%;
 	padding: 0 8px;
 	border-left: 2px solid blue;
 	background: rgba(0, 0, 255, 0.05);
+}
+
+article.rapido > footer pre > mark > code {
+	border-left: 2px solid #353839;
+	background: rgba(0, 0, 0, 0.05);
 }
 
 /* end code */


### PR DESCRIPTION
This PR introduces the **article footer**: a place at the end of the article where to add footnotes, references, etc.. I took heavy inspiration from https://distill.pub/, for example, look at the footer of [this article](https://distill.pub/2018/differentiable-parameterizations/).

Even if the documentation does not tell that, the CSS code implements both implicit and explicit sectioning, with a slightly different style:

``` 
<!-- implicit -->
<footer>
  <h1>...</h1>
  <p>...</p>
  <h1>...</h1>
  <p>...</p>
</footer>
```  

``` 
<!-- explicit -->
<footer>
  <section>
    <h1>...</h1>
    <p>...</p>
  </section>
  <section>
    <h1>...</h1>
    <p>...</p>
  </section>
</footer>
```  

Please review both the presentation (documentation and style) and the implemented CSS code, thanks.

