### PR TITLE
close #7 | review text

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,8 +43,7 @@
           <h1>Rapido: semantic HTML elements for your writings.</h1>
           <p>Rapido provides a default style for a set of <strong>semantic HTML</strong> elements that you can use to compose your essays. No CSS or JS is required.</p>
           <p>The present document has been created using Rapido, you can easily get documents or blog posts with the same layout and style. See how to use Rapido in the next sections.</p>
-          <p>Rapido is open source, view it on <a href="https://github.com/nextbitlabs/Rapido">Github</a>.
-          </p>
+          <p>Rapido is open source, view it on <a href="https://github.com/nextbitlabs/Rapido">Github</a>.</p>
         </header>
         <section>
           <h1>Motivation</h1>

--- a/index.html
+++ b/index.html
@@ -36,23 +36,8 @@
     <link href="./normalize.css" rel="stylesheet" type="text/css">
     <link href="./rapido.css" rel="stylesheet" type="text/css">
   </head>
-  <body class="rapido">
+  <body>
     <main>
-      <header>
-        <button><a href="#">☰</a></button>
-        <nav class="nav">
-          <ul>
-            <li>
-              <a href="https://github.com/nextbitlabs/Rapido">
-                View on Github
-                <img src="./media/github.svg">
-              </a>
-            </li>
-          </ul>
-        </nav>
-        <button><a href="#">close menu</a></button>
-        <img src="./media/icon.svg"></img>
-      </header>
       <article class="rapido">
         <header>
           <h1>Rapido: semantic HTML elements for your writings.</h1>
@@ -534,65 +519,7 @@
             </figcaption>
           </figure>
         </section>
-
-        <section>
-          <h1>Navigation menu</h1>
-          <p>The present section describes how to add a navigation menu at the top of your document. The menu may have one or more links to external resources, like other web pages, or links to sections of the same document as well.</p>
-          <p>As with all the other features, having a menu is optional and it is up to you if the document provides a navigation menu or not. For the menu, we use the <code>&lt;nav&gt;</code> element inside the document header. Note that the document header is created with the <code>&lt;header&gt;</code> element, which is positioned in the <code>&lt;main&gt;</code> element just before the <code>&lt;article&gt;</code> element.</p>
-          <figure>
-            <pre><code>&lt;main&gt;</code>
-<mark><code>  &lt;header&gt;
-    &lt;button&gt;&lt;a href="#"&gt;☰&lt;/a&gt;&lt;/button&gt;
-    &lt;nav class="nav"&gt;
-      &lt;ul&gt;
-        &lt;li&gt;
-          &lt;a href="..."&gt;
-            ...
-            &lt;img src="..."&gt;
-          &lt;/a&gt;
-        &lt;/li&gt;
-        &lt;li&gt;...&lt;/li&gt;
-      &lt;/ul&gt;
-    &lt;/nav&gt;
-    &lt;button&gt;&lt;a href="#"&gt;close menu&lt;/a&gt;&lt;/button&gt;
-  &lt;/header&gt;</code></mark>
-<code>  &lt;article&gt;
-    ...
-  &lt;/article&gt;
-&lt;/main&gt;</code></pre>
-            <figcaption>
-              <p>Code snippet for a navigation menu. Each link is created with the <code>&lt;a&gt;</code> element inside the <code>&lt;li&gt;</code> element. An image, typically an icon, may be pulled together the link label inside the <code>&lt;a&gt;</code> element.</p>
-            </figcaption>
-          </figure>
-          <p>The code above shows the presence of a couple of <code>&lt;button&gt;</code> elements, they are necessary for having a responsive navigation menu on small screens, as shown in the next screenshot.</p>
-          <figure>
-            <img src="./media/responsive.png">
-            <figcaption>
-              <h1>Responsive navigation menu.</h1>
-              <p>Screenshot of <a href="https://www.mozilla.org/en-US/firefox/developer/">Firefox</a> developer tools.</p>
-              <p>The <code>&lt;button&gt;</code> elements provide a way to open and close the menu on small screens, supporting menu with one or more links.</p>
-        </section>
-
-        <section>
-          <h1>Copyrights</h1>
-          <p>This section describes how to place the copyright notice at the bottom of the document. You can add a copyright notice through a paragraph within the <code>&lt;footer&gt;</code> element.</p>
-          <figure>
-            <pre><code>&lt;main&gt;
-  ...</code>
-<mark><code>  &lt;footer&gt;
-    &lt;p&gt;&lt;small&gt;...&lt;/small&gt;&lt;/p&gt;
-  &lt;/footer&gt;</code></mark>
-<code>&lt;/main&gt;</code></pre>
-            <figcaption>
-              <h1>Code snippet for stating content attribution or licensing.</h1>
-              <p>Note that the <code>&lt;footer&gt;</code> element has to be the last child of the <code>&lt;main&gt;</code> element.</p>
-            </figcaption>
-          </figure>
-        </section>
       </article>
-      <footer>
-        <p><small>Created with &lt;3 in <a href="https://open.nextbit.it/">Nextbit</a> | <a href="https://github.com/nextbitlabs/Rapido/blob/master/LICENSE">MIT License</a></small></p>
-      </footer>
     </main>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -5,33 +5,35 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=yes">
     <title>Rapido</title>
-    <meta name="description" content="Rapido: create web documents with the only use of HTML snippets.">
+    <meta name="description" content="Rapido: semantic HTML elements for your writings.">
     <meta name="robots" content="index,follow">
 
     <link rel="icon" type="image/png" href="favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="favicon-16x16.png" sizes="16x16" />
 
-    <!-- <meta property="og:url" content="https://damneat.nextbit.it/index.html"> -->
+    <meta property="og:url" content="https://nextbitlabs.github.io/Rapido/">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Rapido">
-    <!-- <meta property="og:image" content="https://damneat.nextbit.it/images/intro.png"> -->
-    <meta property="og:description" content="">
+    <!-- <meta property="og:image" content="https://nextbitlabs.github.io/Rapido/images/intro.png"> -->
+    <meta property="og:description" content="Rapido: semantic HTML elements for your writings.">
     <!-- <meta property="og:site_name" content="nextbit.it"> -->
     <meta property="og:locale" content="en_US">
 
-    <meta name="twitter:card" content="">
-    <!-- <meta name="twitter:url" content="https://damneat.nextbit.it/index.html"> -->
+    <meta name="twitter:card" content="Rapido: semantic HTML elements for your writings.">
+    <meta name="twitter:url" content="https://nextbitlabs.github.io/Rapido/">
     <meta name="twitter:title" content="Rapido">
-    <meta name="twitter:description" content="">
-    <!-- <meta name="twitter:image" content="https://damneat.nextbit.it/images/intro.png"> -->
+    <meta name="twitter:description" content="Rapido: semantic HTML elements for your writings.">
+    <!-- <meta name="twitter:image" content="https://nextbitlabs.github.io/Rapido/images/intro.png"> -->
 
     <meta itemprop="name" content="Rapido">
-    <meta itemprop="description" content="">
-    <!-- <meta itemprop="image" content="https://damneat.nextbit.it/images/intro.png"> -->
+    <meta itemprop="description" content="Rapido: semantic HTML elements for your writings.">
+    <!-- <meta itemprop="image" content="https://nextbitlabs.github.io/Rapido/images/intro.png"> -->
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0-rc.1/dist/katex.min.css" integrity="sha384-D+9gmBxUQogRLqvARvNLmA9hS2x//eK1FhVb9PiU86gmcrBrJAQT8okdJ4LMp2uv" crossorigin="anonymous">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.0-rc.1/dist/katex.min.js" integrity="sha384-483A6DwYfKeDa0Q52fJmxFXkcPCFfnXMoXblOkJ4JcA8zATN6Tm78UNL72AKk+0O" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.0-rc.1/dist/contrib/auto-render.min.js" integrity="sha384-yACMu8JWxKzSp/C1YV86pzGiQ/l1YUfE8oPuahJQxzehAjEt2GiQuy/BIvl9KyeF" crossorigin="anonymous" onload="renderMathInElement(document.body,{delimiters: [{left: '$$', right: '$$', display: true},{left: '$', right: '$', display: false}]});"></script>
+
+    <link href="./normalize.css" rel="stylesheet" type="text/css">
     <link href="./rapido.css" rel="stylesheet" type="text/css">
   </head>
   <body class="rapido">
@@ -51,52 +53,68 @@
         <button><a href="#">close menu</a></button>
         <img src="./media/icon.svg"></img>
       </header>
-      <article>
+      <article class="rapido">
         <header>
-          <h1>Welcome to Rapido</h1>
-          <p><strong>Rapido</strong> helps you to write web documents with the only use of HTML snippets, it is designed with a focus on usability and frugality.</p>
-          <p>The present documentation has been created following Rapido guidelines and nothing more, you can easily get your own documents with the same layout and style. Rapido guidelines are described in the next sections.</p>
+          <h1>Rapido: semantic HTML elements for your writings.</h1>
+          <p>Rapido provides a default style for a set of <strong>semantic HTML</strong> elements that you can use to compose your essays. No CSS or JS is required.</p>
+          <p>The present document has been created using Rapido, you can easily get documents or blog posts with the same layout and style. See how to use Rapido in the next sections.</p>
+          <p>Rapido is open source, view it on <a href="https://github.com/nextbitlabs/Rapido">Github</a>.
+          </p>
         </header>
         <section>
+          <h1>Motivation</h1>
+          <p>Having your own corner on the web where you can freely share thoughts or technical stuff <a href="https://medium.com/@dan_abramov/why-my-new-blog-isnt-on-medium-3b280282fbae">is still cool</a>, and the popularity of tools like <a href="https://jekyllrb.com/">Jekyll</a> or <a href="https://www.gatsbyjs.org/">Gatsby</a> proves that. Rapido intervenes there, offering semantic HTML templates for a variety of typical author needs: like header, sections, side notes, references and so on.<small>The importance of using <a href="https://developer.mozilla.org/en-US/docs/Glossary/semantics#Semantics_in_HTML">semantic HTML</a> is a common theme in web development, it is a good idea to use the relevant HTML element for the job. Semantic HTML improves the usability of the code and ensures maximum <a href="https://developer.mozilla.org/en-US/docs/Learn/Accessibility/HTML">accessibility</a>.</small></p>
+          <p>Rapido has been crafted with the idea that using semantic HTML for your writings <em>can be easy</em>. For such a reason Rapido does not make use of CSS classes or Javascript hooks, the author can compose all the different parts of the document with semantic HTML elements, for example adding side notes in paragraphs with the <code>&lt;small&gt;</code> element.</p>
+        </section>
+        <section>
           <h1 id="getting-started">Getting started</h1>
-          <p>As starting point, we need an html document. The following code provides a skeleton: create an html file, called for example <code>document.html</code>, and copy/paste the code in the file.</p>
+          <p>Rapido provides style rules in the <code>rapido.css</code> stylesheet, you can download the CSS file from <a href="https://raw.githubusercontent.com/nextbitlabs/Rapido/master/rapido.css">Github</a> and link to it within the <code>&lt;head&gt;</code> element in your document.</p>
+          <figure>
+            <pre><code>&lt;head&gt;</code>
+<mark><code>  &lt;link href="https://unpkg.com/@nextbitlabs/rapido@latest/rapido.css" rel="stylesheet" type="text/css"&gt;</code></mark>
+<code>&lt;/head&gt;</code></pre>
+          </figure>
+          <p>The style rules defined in <code>rapido.css</code> are name-spaced under the CSS class <code>rapido</code>. Being Rapido thought for web essays, the best place to use the CSS class is the <code>&lt;article&gt;</code> element, as showed in the next snippet.</p>
+          <figure>
+              <pre><code>&lt;main&gt;</code>
+<mark><code>  &lt;article class="rapido"&gt;
+    ...
+  &lt;/article&gt;</code></mark>
+<code>&lt;/main&gt;</code></pre>
+            <figcaption>
+              <h1>Assign CSS class <code>rapido</code> to the <code>&lt;article&gt;</code> element.</h1>
+              <p>Rapido can be used in a web document created from scratch or within an existing document, the CSS class <code>rapido</code> makes Rapido not invasive with respect to existing CSS code.</p>
+            </figcaption>
+          </figure>
+          <h2>Get your hands dirty</h2>
+          <p>If you want to try Rapido then you  need the skeleton of an HTML document. The next code snippet provides a minimal template, copy the snippet in a fresh HTML file.</p>
           <figure>
               <pre><code>&lt;!DOCTYPE html&gt;
 &lt;html&gt;
   &lt;head&gt;
     &lt;meta charset="utf-8"&gt;
     &lt;meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=yes"&gt;
-    &lt;link href="rapido.css" rel="stylesheet" type="text/css"&gt;
+    &lt;link href="https://unpkg.com/@nextbitlabs/rapido@latest/rapido.css" rel="stylesheet" type="text/css"&gt;
   &lt;/head&gt;
-  &lt;body class="rapido"&gt;
+  &lt;body&gt;
     &lt;main&gt;
-      &lt;article&gt;
+      &lt;article class="rapido"&gt;
         ...
       &lt;/article&gt;
     &lt;/main&gt;
   &lt;/body&gt;
 &lt;/html&gt;</code></pre>
             <figcaption>
-              <p>This the first example of an html snippet. Rapido is just that: copy and paste the html snippets and fill the gaps <code>...</code> with your own content.</p>
+              <h1>Minimal skeleton of an HTML document.</h1>
+              <p>Note the presence of the stylesheet <code>rapido.css</code> within the <code>&lt;head&gt;</code> element, it defines the style rules and it is all you need to use Rapido.</p>
             </figcaption>
           </figure>
-          <p>Note that Rapido can be used in a web document created from scratch or within an existing document, the CSS class <code>class="rapido"</code> makes Rapido not invasive with respect existing CSS code. Generally speaking, you will want to assign the class <code>rapido</code> to the HTML container of your document, for example in
-            <figure>
-              <pre><code>&lt;article class="rapido"&gt;
-  ...
-&lt;article&gt;</code></pre>
-            </figure>
-          </p>
-          <p>The css stylesheet <code>rapido.css</code> can be downloaded from <a href="https://raw.githubusercontent.com/nextbitlabs/Rapido/master/rapido.css">github</a>, in alternative you can simply use the following line within element <code>&lt;head&gt;</code>.</p>
-          <figure>
-            <pre><code>&lt;link href="https://unpkg.com/@nextbitlabs/rapido@latest/rapido.css" rel="stylesheet" type="text/css"&gt;</code></pre>
-          </figure>
-          <p>The next sections describe how to replace the ellipsis <code>...</code> with content of interest, like paragraph, figures, tables and so on.</p>
+          <p>The next sections describe how to replace the ellipsis with the content of interest, like paragraphs, figures, tables and so on. Rapido is just that: copy and paste the HTML snippets and fill the gaps with your own content.</p>
         </section>
 
         <section>
           <h1>Sections</h1>
-          <p>The previous section shows a gap within the <code>&lt;article&gt;...&lt;/article&gt;</code> tags, you can fill the gap with <strong>section</strong> snippets. Typically, sections have a heading and one or more paragraphs, but not only, as we will see sections may also contain figures, tables and much more.</p>
+          <p>The previous code snippet shows a gap within the <code>&lt;article&gt;</code> element, you can fill the gap with <strong>sections</strong>. Typically, sections have a heading and one or more paragraphs. Moreover, sections may also contain figures, tables and much more.</p>
           <figure>
             <pre><code>&lt;main&gt;
   &lt;article&gt;</code>
@@ -104,19 +122,21 @@
       &lt;h1&gt;...&lt;/h1&gt;
       &lt;p&gt;...&lt;/p&gt;
       &lt;p&gt;...&lt;/p&gt;
+      &lt;h2&gt;...&lt;/h2&gt;
+      &lt;p&gt;...&lt;/p&gt;
     &lt;/section&gt;</code></mark>
 <code>  &lt;/article&gt;
 &lt;/main&gt;</code></pre>
             <figcaption>
-              <p>A section with a heading and two paragraphs.</p>
+              <h1>Code snippet of a section.</h1>
+              <p>The example shows a section with a heading and two paragraphs, a lower level heading and another paragraph.</p>
             </figcaption>
           </figure>
-          <p>The html snippet above creates a section with some content, at this moment you can successfully open your <code>document.html</code> file with a browser.</p>
         </section>
 
         <section>
           <h1>Title and abstract</h1>
-          <p>Element <code>&lt;header&gt;</code> is used for the title and few introductory paragraphs of your document. Generally, it is placed as first element within the <code>&lt;article&gt;</code> tag.</p>
+          <p>The <code>&lt;header&gt;</code> element is used for the title and few introductory paragraphs of your document. Generally, it is placed as the first element within the <code>&lt;article&gt;</code> element.</p>
           <figure>
             <pre><code>&lt;main&gt;
   &lt;article&gt;</code>
@@ -134,15 +154,16 @@
   &lt;/article&gt;
 &lt;/main&gt;</code></pre>
             <figcaption>
-              <p>Code snippet for the document header. Element <code>&lt;address&gt;</code> is optional, it can be used to indicate the contact information of the authors. Element <code>&lt;img&gt;</code> is also optional, it should be the avatar image.</p>
+              <h1>Code snippet for the document header.</h1>
+              <p>The element <code>&lt;address&gt;</code> can be used to indicate the contact information of the authors. The element <code>&lt;img&gt;</code> is useful for adding the author avatar.</p>
             </figcaption>
           </figure>
-          <p>On the following, code snippets are supposed to be pasted inside element <code>&lt;article&gt;</code>, so that tags <code>&lt;main&gt;</code> and <code>&lt;article&gt;</code> are understood and can be omitted.</p>
+          <p>The header may also contain full-width images, as described in section <strong><a href="#images-and-videos">Images and videos</a></strong>.</p>
         </section>
 
         <section>
           <h1>Side comments</h1>
-          <p>This section describes how to add a <strong>side comment</strong>. Side comments typically show parenthetical content considered part of the main flow, like qualifying remarks directly related to the section.<small>Side comments are related to the paragraph, therefore they usually appear right or below the text of the paragraph. <img src="./media/ga.jpg"> As indicated in the code snippet, side comments may also contain pictures, added by means of the <code>&lt;img&gt;</code> tag.</small></p>
+          <p>This section describes how to add a <strong>side comment</strong>. Side comments typically show parenthetical content considered part of the main flow, like qualifying remarks directly related to the section.<small>Side comments are related to the paragraph, therefore they usually appear right or below the text of the paragraph. <img src="./media/ga.jpg">.</small></p>
           <p>A side comment should be inserted within the paragraph of a section, it will appear at the right of the paragraph and vertically aligned with it, or just below the paragraph on smaller screens.</p>
           <figure>
             <pre><code>&lt;section&gt;
@@ -153,12 +174,16 @@
 <code>    ...
   &lt;/p&gt;
 &lt;/section&gt;</code></pre>
+            <figcaption>
+              <h1>Code snippet of a side comment.</h1>
+              <p>Side comments may also contain pictures, added by means of the <code>&lt;img&gt;</code> element.</p>
+            </figcaption>
           </figure>
         </section>
 
         <section>
-          <h1>Images and videos</h1>
-          <p>Both images and videos are displayed within <code>&lt;figure&gt;...&lt;/figure&gt;</code> tags, possibly supplied with a caption. Tag <code>&lt;figure&gt;</code> is supposed to be positioned near the paragraph where the image (or video) is mentioned. Tag <code>&lt;figcaption&gt;</code> can contain a heading and one or more paragraphs.</p>
+          <h1 id="images-and-videos">Images and videos</h1>
+          <p>Both images and videos are displayed within the <code>&lt;figure&gt;</code> element, possibly supplied with a caption. The <code>&lt;figure&gt;</code> element is supposed to be positioned near the paragraph where the image (or video) is mentioned. The <code>&lt;figcaption&gt;</code> element can contain a heading and one or more paragraphs.</p>
           <figure>
             <img src="./media/voronoi.jpg">
             <figcaption>
@@ -179,11 +204,12 @@
 <code>  &lt;p&gt;...&lt;/p&gt;
 &lt;/section&gt;</code></pre>
             <figcaption>
-              <p>Code snippet of an image, with a descriptive caption. For explanatory purpose, tag <code>&lt;figure&gt;</code> has been presented within a section with a heading and two paragraphs.</p>
-              <p>Images can also be inserted in the article header, in that case, the image will have full width.</p>
+              <h1>Code snippet of an image, with a descriptive caption.</h1>
+              <p>The article header may contain a picture as well, in that case, the image will have full width.</p>
             </figcaption>
           </figure>
-          <p>Exactly the same html snipped is used for displaying videos, with the obvious difference of using tag <code>&lt;video&gt;</code> in place of tag <code>&lt;img&gt;</code>, as shown below.</p>
+          <h2>Videos</h2>
+          <p>Exactly the same HTML code snippet is used for displaying videos, with the obvious difference of using the <code>&lt;video&gt;</code> element in place of the <code>&lt;img&gt;</code> element, as shown below.</p>
           <figure>
             <video controls muted src="./media/smoke.mp4"></video>
             <figcaption>
@@ -204,15 +230,16 @@
 <code>  &lt;p&gt;...&lt;/p&gt;
 &lt;/section&gt;</code></pre>
             <figcaption>
-              <p>Code snippet of a video with a caption, the latter having a heading and a paragraph. As with images, videos can be inserted in the article header as well.</p>
+              <h1>Code snippet of a video with a caption.</h1>
+              <p>As with images, videos can be inserted in the article header.</p>
             </figcaption>
           </figure>
         </section>
 
         <section>
           <h1>Quotations</h1>
-          <p>This section shows how to add <strong>quotations</strong> into your document. Element <code>&lt;blockquote&gt;</code> can be inserted in a section within other paragraphs and may contains one or more paragraphs as well.</p>
-          <blockquote cite="https://html.spec.whatwg.org/multipage/grouping-content.html#the-blockquote-element">
+          <p>This section shows how to add <strong>quotations</strong> from another source into your document. The <code>&lt;blockquote&gt;</code> element can be inserted in a section within other paragraphs and may contain one or more paragraphs as well.</p>
+          <blockquote cite="https://HTML.spec.whatwg.org/multipage/grouping-content.HTML#the-blockquote-element">
             <p>Content inside a blockquote must be quoted from another source, whose address, if it has one, may be cited in the cite attribute.</p>
           </blockquote>
           <cite>HTML Living Standard</cite>
@@ -220,24 +247,24 @@
             <pre><code>&lt;section&gt;
   &lt;h1&gt;...&lt;/h1&gt;
   &lt;p&gt;...&lt;/p&gt;</code>
-<mark><code>  &lt;blockquote cite="..."&gt;
+<mark><code>  &lt;blockquote cite="https://..."&gt;
     &lt;p&gt;...&lt;/p&gt;
   &lt;/blockquote&gt;
   &lt;cite&gt;...&lt;/cite&gt;</code></mark>
 <code>  &lt;p&gt;...&lt;/p&gt;
 &lt;/section&gt;</code></pre>
             <figcaption>
-              <p>HTML snippet of a quotation from another source.</p>
+              <h1>Code snippet of a quotation from another source.</h1>
+              <p>If appropriate, use the <code>cite</code> attribute for adding a URL of the quotation source and the <code>&lt;cite&gt;</code> element for the text representation.</p>
             </figcaption>
           </figure>
-          <p>If appropriate, use the <code>cite</code> attribute for adding a URL of the quotation source and the <code>&lt;cite&gt;</code> element for the text representation, both of them are optional.</p>
         </section>
 
         <section>
           <h1>Highlights</h1>
-          <p>The repetition of some content from the same source is used for the purposes of enticing readers or highlighting key topics. You can repeat a passage or an entire paragraph using element <code>&lt;aside&gt;</code> inside a section.</p>
+          <p>The repetition of some content from the same source is used for the purposes of enticing readers or highlighting key topics. You can repeat a passage or an entire paragraph using the <code>&lt;aside&gt;</code> element inside a section.</p>
           <aside>
-            <p><strong>Rapido</strong> is just that: copy and paste the html snippets and fill the gaps.</p>
+            <p><strong>Rapido</strong> is just that: copy and paste the HTML snippets and fill the gaps.</p>
           </aside>
           <figure>
             <pre><code>&lt;section&gt;
@@ -249,15 +276,15 @@
 <code>  &lt;p&gt;...&lt;/p&gt;
 &lt;/section&gt;</code></pre>
             <figcaption>
-              <p>HTML snippet of an highlight.</p>
+              <h1>Code snippet of an highlight.</h1>
+              <p>Highlights are styled with a font bigger than the surrounding text.</p>
             </figcaption>
           </figure>
-          <p>Such kind of quotations highlight pieces of information and therefore they are styled with a font bigger than the surrounding text.</p>
         </section>
 
         <section>
           <h1>Tables</h1>
-          <p>As well as with images and videos, tables also are displayed within a figure and can be described by a caption. Tables are useful for displaying tabular data and they are disegned to visualise several columns: if the table is bigger than the window width the hidden part is visible through mouse scrolling.</p>
+          <p>As well as with images and videos, tables are displayed within the <code>&lt;figure&gt;</code> element, with an optional caption. Tables are useful for displaying tabular data with few or several columns, if the table is bigger than the window width the hidden part is visible through mouse scrolling.</p>
           <figure>
             <div>
               <table>
@@ -320,20 +347,21 @@
 <code>  &lt;p&gt;...&lt;/p&gt;
 &lt;/section&gt;</code></pre>
             <figcaption>
-              <p>Code snippet of a table of two columns, with a heading and two rows. Use part <code>&lt;thead&gt;</code> for defining the head of the columns of the table, use instead part <code>&lt;tbody&gt;</code> for the body of the table. Note that, differently from images and videos, there is an extra <code>&lt;div&gt;</code> container wrapping the <code>&lt;table&gt;</code> element.</p>
+              <h1>Code snippet of a table.</h1>
+              <p>The <code>&lt;thead&gt;</code> element defines the head of the table columns, instead, the <code>&lt;tbody&gt;</code> element is used for the table body. Note that, differently from images and videos, there is an extra <code>&lt;div&gt;</code> container wrapping the <code>&lt;table&gt;</code> element.</p>
             </figcaption>
           </figure>
         </section>
 
         <section>
           <h1>Lists</h1>
-          <p>As usual, lists are created with tags <code>&lt;ul&gt;</code> and <code>&lt;ol&gt;</code>, whereas <code>&lt;li&gt;</code> element is used to represent list items.</p>
+          <p>Lists are created with the <code>&lt;ul&gt;</code> and <code>&lt;ol&gt;</code> elements, whereas <code>&lt;li&gt;</code> element is used to represent list items.</p>
           <ul>
             <li>
-              <p>use tag <code>&lt;ol&gt;</code> for ordered lists</p>
+              <p>use the <code>&lt;ol&gt;</code> element for ordered lists</p>
             </li>
             <li>
-              <p>use tag <code>&lt;ul&gt;</code> for unordered lists</p>
+              <p>use the <code>&lt;ul&gt;</code> element for unordered lists</p>
             </li>
           </ul>
           <figure>
@@ -351,7 +379,8 @@
 <code>  &lt;p&gt;...&lt;/p&gt;
 &lt;/section&gt;</code></pre>
             <figcaption>
-              <p>Use <code>&lt;ol&gt;</code> element when the order is meaningful, ordered list are rendered as a numbered list:</p>
+              <h1>Code snippet of code list.</h1>
+              <p>Use the <code>&lt;ol&gt;</code> element when the order is meaningful, ordered list are rendered as a numbered list:</p>
               <ol>
                 <li><p>first item</p></li>
                 <li><p>second item</p></li>
@@ -362,11 +391,12 @@
 
         <section>
           <h1>Code</h1>
-          <p>Code can be inserted inline or within a <code>&lt;figure&gt;</code> node, in the same way as with images and videos.</p>
+          <p>Listings of code can be inserted inline inside a paragraph or within element <code>&lt;figure&gt;</code> for multiple lines of code.</p>
           <figure>
             <pre><code>&lt;p&gt;...<mark>&lt;code&gt;...&lt;/code&gt;</mark>...&lt;/p&gt;</code></pre>
             <figcaption>
-              <p>Add inline code using tag <code>&lt;code&gt;</code>.</p>
+              <h1>Code snippet of code listings.</h1>
+              <p>Add inline code using the <code>&lt;code&gt;</code> element.</p>
             </figcaption>
           </figure>
           <figure>
@@ -374,7 +404,7 @@
 <mark><code>  &lt;pre&gt;&lt;code&gt;...&lt;/code&gt;&lt;/pre&gt;</code></mark>
 <code>&lt;/figure&gt;</code></pre>
             <figcaption>
-              <p>Wrap the <code>&lt;code&gt;</code> element within a <code>&lt;pre&gt;</code> element to add multiple lines of code.</p>
+              <p>Wrap the <code>&lt;code&gt;</code> element within the <code>&lt;pre&gt;</code> element to add multiple lines of code.</p>
             </figcaption>
           </figure>
           <h2>Example 1</h2>
@@ -384,17 +414,17 @@
               <p>Factorial function in Javascript. </p>
             </figcaption>
           </figure>
+          <p>The next code snippet shows how to write the factorial function above.</p>
           <figure>
             <pre><code>&lt;figure&gt;
   &lt;pre&gt;&lt;code&gt;const f = n => n ? n * f(n - 1) : 1;&lt;/code&gt;&lt;/pre&gt;
 &lt;/figure&gt;</code></pre>
             <figcaption>
               <h1>Listing 1</h1>
-              <p>Code snippet used for the factorial function above.</p>
             </figcaption>
           </figure>
           <h2>Example 2</h2>
-          <p>This example shows how to obtain the expected indentation with more lines of code. As rule of thumb, paste the code directly within elements <code>&lt;pre&gt;&lt;code&gt;...&lt;/code&gt;&lt;/pre&gt;</code>.</p>
+          <p>This example shows how to obtain the expected indentation with more lines of code. As rule of thumb, paste the code directly within the <code>&lt;pre&gt;&lt;code&gt;...&lt;/code&gt;&lt;/pre&gt;</code> elements.</p>
           <figure>
             <pre><code>function factorial (n) {
   return n ? n * factorial(n - 1) : 1;
@@ -416,11 +446,21 @@
 &amp;lt;/figure&amp;gt;&lt;/code&gt;&lt;/pre&gt;
 &lt;/figure&gt;</code></pre>
             <figcaption>
-              <p>Snippet used for writing the HTML code of <a href="#listing1">listing 1</a>.</p>
+              <p>Snippet used for the HTML code of <a href="#listing1">listing 1</a>.</p>
             </figcaption>
           </figure>
-          <h2>Highlighting code</h2>
-          <p>You can highlight code in two different ways: inline or for multiple lines. Highlighting a portion of a line can be done using tag <code>&lt;mark&gt;</code> as in <code>&lt;code&gt;...&lt;mark&gt;...&lt;/mark&gt;...&lt;/code&gt;</code>. Instead, one or more lines of code can be fully highlighted wrapping the full line within tag <code>&lt;mark&gt;</code>, as in <code>&lt;mark&gt;&lt;code&gt;...&lt;/code&gt;&lt;/mark&gt;</code>. The next snippet shows an example.</p>
+          <h2>Highlight code</h2>
+          <p>You can highlight code in two different ways: inline or full lines.</p>
+          <figure>
+            <pre><code>&lt;figure&gt;
+  &lt;pre&gt;&lt;code&gt;...<mark>&lt;mark&gt;...&lt;/mark&gt;</mark>...&lt;/code&gt;&lt;/pre&gt;
+&lt;/figure&gt;</code></pre>
+            <figcaption>
+              <h1>Highlight a portion of a line.</h1>
+              <p>Wrap the relevant code within the <code>&lt;mark&gt;</code> element.</p>
+            </figcaption>
+          </figure>
+          <p>Instead, highlight one or more lines of code wrapping the full line within the <code>&lt;mark&gt;</code> element, the next snippet shows an example.</p>
           <figure>
             <pre><code>&lt;figure&gt;</code>
 <code>  &lt;pre&gt;&lt;code&gt;...&lt;/code&gt;</code>
@@ -428,21 +468,22 @@
 <code>&lt;code&gt;...&lt;/code&gt;&lt;/pre&gt;</code>
 <code>&lt;/figure&gt;</code></pre>
             <figcaption>
-              <p>Highlight multiple lines of code. Note that, within <code>&lt;pre&gt;</code> tags, indetation spaces and new lines are displayed on screen, therefore they deserve a special attention in order to represent the right code indentation.</p>
+              <h1>Highlight full lines of code.</h1>
+              <p>Note that, within the <code>&lt;pre&gt;</code> element, indentation spaces and new lines deserve special attention in order to represent the right code formatting.</p>
             </figcaption>
           </figure>
         </section>
 
         <section>
           <h1>Math formulas</h1>
-          <p>Math typesetting is not supported by default. We suggest to use <a href="https://katex.org/">KaTeX</a>, a popular JavaScript library for TeX math rendering on the web. If this is also your way, then copy and paste the next code within the <code>&lt;head&gt;...&lt;/head&gt;</code> elements (see section <a href="#getting-started"><strong>Getting Started</strong></a>) to get KaTeX working.</p>
+          <p>Math typesetting is not supported by default. We suggest using <a href="https://katex.org/">KaTeX</a>, a popular JavaScript library for TeX math rendering on the web. To get KaTex working, copy and paste the next code within the <code>&lt;head&gt;</code> element (see section <a href="#getting-started"><strong>Getting Started</strong></a>).</p>
           <figure>
             <pre><code>&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0-rc.1/dist/katex.min.css" integrity="sha384-D+9gmBxUQogRLqvARvNLmA9hS2x//eK1FhVb9PiU86gmcrBrJAQT8okdJ4LMp2uv" crossorigin="anonymous"&gt;
 &lt;script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.0-rc.1/dist/katex.min.js" integrity="sha384-483A6DwYfKeDa0Q52fJmxFXkcPCFfnXMoXblOkJ4JcA8zATN6Tm78UNL72AKk+0O" crossorigin="anonymous"&gt;&lt;/script&gt;
 &lt;script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.0-rc.1/dist/contrib/auto-render.min.js" integrity="sha384-yACMu8JWxKzSp/C1YV86pzGiQ/l1YUfE8oPuahJQxzehAjEt2GiQuy/BIvl9KyeF" crossorigin="anonymous" onload="renderMathInElement(document.body,{delimiters: [{left: '$$', right: '$$', display: true},{left: '$', right: '$', display: false}]});"&gt;&lt;/script&gt;</code></pre>
           </figure>
           <h2>Example 1</h2>
-          <p>You can insert mathematics inline a paragraph, like the famous equivalence between energy and inertial mass $E = mc^2$, surrounding the mathematical formula with symbols <code>$...$</code>, as presented below.</p>
+          <p>You can insert mathematics inline on a paragraph, like the famous equivalence between energy and inertial mass $E = mc^2$, surrounding the mathematical formula with symbols <code>$...$</code>, as presented below.</p>
           <figure>
             <pre><code>&lt;p&gt;... $E = mc^2$ ...&lt;/p&gt;</code></pre>
             <figcaption>
@@ -460,7 +501,7 @@
 &lt;/p&gt;</code></pre>
           </figure>
           <h2>Example 3</h2>
-          <p>Multiline math can be obtained with TeX syntax, <a href="https://katex.org/docs/supported.html">KaTeX supports</a> a wide list of TeX functions. For example, for the representation of the following system of equations we make use of the <code>\begin{array}</code> environment.</p>
+          <p>KaTeX <a href="https://katex.org/docs/supported.HTML">supports</a> a wide list of TeX functions. For example, for the representation of the following system of equations, we make use of the <code>\begin{array}</code> environment.</p>
           <figure>
             <p>
               $$\begin{array}{rcl}
@@ -497,7 +538,7 @@
         <section>
           <h1>Navigation menu</h1>
           <p>The present section describes how to add a navigation menu at the top of your document. The menu may have one or more links to external resources, like other web pages, or links to sections of the same document as well.</p>
-          <p>As with all the other features, having a menu is optional and it is up to you if the document provides a navigation or not. For the menu we use the element <code>&lt;nav&gt;</code> inside the document header. Note that the document header is created with element <code>&lt;header&gt;</code>, which is positioned in <code>&lt;main&gt;</code> just before the <code>&lt;article&gt;</code> element.</p>
+          <p>As with all the other features, having a menu is optional and it is up to you if the document provides a navigation menu or not. For the menu, we use the <code>&lt;nav&gt;</code> element inside the document header. Note that the document header is created with the <code>&lt;header&gt;</code> element, which is positioned in the <code>&lt;main&gt;</code> element just before the <code>&lt;article&gt;</code> element.</p>
           <figure>
             <pre><code>&lt;main&gt;</code>
 <mark><code>  &lt;header&gt;
@@ -520,21 +561,21 @@
   &lt;/article&gt;
 &lt;/main&gt;</code></pre>
             <figcaption>
-              <p>Code snippet for a navigation menu. Each link is created with a <code>&lt;a&gt;</code> element inside a <code>&lt;li&gt;</code>. An image, tipically an icon, may be pulled together the link label inside <code>&lt;a&gt;</code>.</p>
+              <p>Code snippet for a navigation menu. Each link is created with the <code>&lt;a&gt;</code> element inside the <code>&lt;li&gt;</code> element. An image, typically an icon, may be pulled together the link label inside the <code>&lt;a&gt;</code> element.</p>
             </figcaption>
           </figure>
           <p>The code above shows the presence of a couple of <code>&lt;button&gt;</code> elements, they are necessary for having a responsive navigation menu on small screens, as shown in the next screenshot.</p>
           <figure>
             <img src="./media/responsive.png">
             <figcaption>
-              <h1>Responsive navigation menu</h1>
+              <h1>Responsive navigation menu.</h1>
               <p>Screenshot of <a href="https://www.mozilla.org/en-US/firefox/developer/">Firefox</a> developer tools.</p>
               <p>The <code>&lt;button&gt;</code> elements provide a way to open and close the menu on small screens, supporting menu with one or more links.</p>
         </section>
 
         <section>
           <h1>Copyrights</h1>
-          <p>This section describes how place the copyright notice at the bottom of the document. You can add a copyright notice through a paragraph <code>&lt;p&gt;</code> within a <code>&lt;footer&gt;</code> element. Note that <code>&lt;footer&gt;</code> has to be the last child of element <code>&lt;main&gt;</code>.</p>
+          <p>This section describes how to place the copyright notice at the bottom of the document. You can add a copyright notice through a paragraph within the <code>&lt;footer&gt;</code> element.</p>
           <figure>
             <pre><code>&lt;main&gt;
   ...</code>
@@ -543,7 +584,8 @@
   &lt;/footer&gt;</code></mark>
 <code>&lt;/main&gt;</code></pre>
             <figcaption>
-              <p>Code snippet for stating content attribution or licensing.</p>
+              <h1>Code snippet for stating content attribution or licensing.</h1>
+              <p>Note that the <code>&lt;footer&gt;</code> element has to be the last child of the <code>&lt;main&gt;</code> element.</p>
             </figcaption>
           </figure>
         </section>

--- a/normalize.css
+++ b/normalize.css
@@ -1,0 +1,349 @@
+/*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
+
+/* Document
+   ========================================================================== */
+
+/**
+ * 1. Correct the line height in all browsers.
+ * 2. Prevent adjustments of font size after orientation changes in iOS.
+ */
+
+html {
+  line-height: 1.15; /* 1 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+}
+
+/* Sections
+   ========================================================================== */
+
+/**
+ * Remove the margin in all browsers.
+ */
+
+body {
+  margin: 0;
+}
+
+/**
+ * Render the `main` element consistently in IE.
+ */
+
+main {
+  display: block;
+}
+
+/**
+ * Correct the font size and margin on `h1` elements within `section` and
+ * `article` contexts in Chrome, Firefox, and Safari.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
+ * 1. Add the correct box sizing in Firefox.
+ * 2. Show the overflow in Edge and IE.
+ */
+
+hr {
+  box-sizing: content-box; /* 1 */
+  height: 0; /* 1 */
+  overflow: visible; /* 2 */
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+pre {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/* Text-level semantics
+   ========================================================================== */
+
+/**
+ * Remove the gray background on active links in IE 10.
+ */
+
+a {
+  background-color: transparent;
+}
+
+/**
+ * 1. Remove the bottom border in Chrome 57-
+ * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+ */
+
+abbr[title] {
+  border-bottom: none; /* 1 */
+  text-decoration: underline; /* 2 */
+  text-decoration: underline dotted; /* 2 */
+}
+
+/**
+ * Add the correct font weight in Chrome, Edge, and Safari.
+ */
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+code,
+kbd,
+samp {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/**
+ * Add the correct font size in all browsers.
+ */
+
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` elements from affecting the line height in
+ * all browsers.
+ */
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/* Embedded content
+   ========================================================================== */
+
+/**
+ * Remove the border on images inside links in IE 10.
+ */
+
+img {
+  border-style: none;
+}
+
+/* Forms
+   ========================================================================== */
+
+/**
+ * 1. Change the font styles in all browsers.
+ * 2. Remove the margin in Firefox and Safari.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit; /* 1 */
+  font-size: 100%; /* 1 */
+  line-height: 1.15; /* 1 */
+  margin: 0; /* 2 */
+}
+
+/**
+ * Show the overflow in IE.
+ * 1. Show the overflow in Edge.
+ */
+
+button,
+input { /* 1 */
+  overflow: visible;
+}
+
+/**
+ * Remove the inheritance of text transform in Edge, Firefox, and IE.
+ * 1. Remove the inheritance of text transform in Firefox.
+ */
+
+button,
+select { /* 1 */
+  text-transform: none;
+}
+
+/**
+ * Correct the inability to style clickable types in iOS and Safari.
+ */
+
+button,
+[type="button"],
+[type="reset"],
+[type="submit"] {
+  -webkit-appearance: button;
+}
+
+/**
+ * Remove the inner border and padding in Firefox.
+ */
+
+button::-moz-focus-inner,
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+/**
+ * Restore the focus styles unset by the previous rule.
+ */
+
+button:-moz-focusring,
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+/**
+ * Correct the padding in Firefox.
+ */
+
+fieldset {
+  padding: 0.35em 0.75em 0.625em;
+}
+
+/**
+ * 1. Correct the text wrapping in Edge and IE.
+ * 2. Correct the color inheritance from `fieldset` elements in IE.
+ * 3. Remove the padding so developers are not caught out when they zero out
+ *    `fieldset` elements in all browsers.
+ */
+
+legend {
+  box-sizing: border-box; /* 1 */
+  color: inherit; /* 2 */
+  display: table; /* 1 */
+  max-width: 100%; /* 1 */
+  padding: 0; /* 3 */
+  white-space: normal; /* 1 */
+}
+
+/**
+ * Add the correct vertical alignment in Chrome, Firefox, and Opera.
+ */
+
+progress {
+  vertical-align: baseline;
+}
+
+/**
+ * Remove the default vertical scrollbar in IE 10+.
+ */
+
+textarea {
+  overflow: auto;
+}
+
+/**
+ * 1. Add the correct box sizing in IE 10.
+ * 2. Remove the padding in IE 10.
+ */
+
+[type="checkbox"],
+[type="radio"] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Correct the cursor style of increment and decrement buttons in Chrome.
+ */
+
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * 1. Correct the odd appearance in Chrome and Safari.
+ * 2. Correct the outline style in Safari.
+ */
+
+[type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
+}
+
+/**
+ * Remove the inner padding in Chrome and Safari on macOS.
+ */
+
+[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * 1. Correct the inability to style clickable types in iOS and Safari.
+ * 2. Change font properties to `inherit` in Safari.
+ */
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
+}
+
+/* Interactive
+   ========================================================================== */
+
+/*
+ * Add the correct display in Edge, IE 10+, and Firefox.
+ */
+
+details {
+  display: block;
+}
+
+/*
+ * Add the correct display in all browsers.
+ */
+
+summary {
+  display: list-item;
+}
+
+/* Misc
+   ========================================================================== */
+
+/**
+ * Add the correct display in IE 10+.
+ */
+
+template {
+  display: none;
+}
+
+/**
+ * Add the correct display in IE 10.
+ */
+
+[hidden] {
+  display: none;
+}

--- a/rapido.css
+++ b/rapido.css
@@ -4,18 +4,7 @@
 	margin: 0;
 }
 
-body.rapido {
-	font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-	-webkit-text-size-adjust: 100%;
-	color: #353839;
-	margin: 0;
-	padding: 0;
-}
-
-article.rapido,
-.rapido article {
+article.rapido {
 	box-sizing: border-box;
 	font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	-webkit-font-smoothing: antialiased;
@@ -29,8 +18,7 @@ article.rapido,
 }
 
 @media (max-width: 1023px) {
-	article.rapido,
-	.rapido article {
+	article.rapido {
 		width: 600px;
 		padding: 0 20px 0 20px;
 	}
@@ -288,8 +276,7 @@ article.rapido,
 	border-right: 1px solid #ededed;
 }
 
-article.rapido small,
-.rapido article small {
+.rapido small {
 	font-size: 14px;
 	line-height: 21px;
 	width: 324px;
@@ -301,8 +288,7 @@ article.rapido small,
 }
 
 @media (max-width: 1023px) {
-	article.rapido small,
-	.rapido article small {
+	.rapido small {
 		width: 100%;
 		float: none;
 		padding: 0;
@@ -313,46 +299,39 @@ article.rapido small,
 	}
 }
 
-article.rapido small > p,
-.rapido article small > p {
+.rapido small > p {
 	font-size: 14px;
 	line-height: 21px;
 }
 
-article.rapido small > img,
-.rapido article small > img {
+.rapido small > img {
 	padding-top: 5px;
 	max-width: 100%;
 }
 
-article.rapido > header,
-.rapido article > header {
+.rapido > header {
 	width: 100%;
 	margin: 50px 0;
 }
 
 @media (min-width: 601px) and (max-width: 1023px) {
-	article.rapido small,
-	.rapido article small {
+	.rapido small {
 		overflow: auto;
 	}
 
-	article.rapido small > img,
-	.rapido article small > img {
+	.rapido small > img {
 		max-width: 324px;
 		float: right;
 	}
 }
 
 @media (max-width: 1023px) {
-	article.rapido > header,
-	.rapido article > header {
+	.rapido > header {
 		margin: 30px 0;
 	}
 }
 
-article.rapido > header > h1,
-.rapido article > header > h1 {
+.rapido > header > h1 {
 	font-size: 60px;
 	line-height: 80px;
 	font-weight: bold;
@@ -360,8 +339,7 @@ article.rapido > header > h1,
 }
 
 .rapido section figcaption > h1,
-article.rapido > header > figure > figcaption > h1,
-.rapido article > header > figure > figcaption > h1 {
+.rapido > header > figure > figcaption > h1 {
 	display: inline;
 	font-size: 14px;
 	font-weight: bold;
@@ -370,30 +348,26 @@ article.rapido > header > figure > figcaption > h1,
 }
 
 @media (max-width: 1023px) {
-	article.rapido > header > h1,
-	.rapido article > header > h1 {
+	.rapido > header > h1 {
 		font-size: 40px;
 		line-height: 60px;
 	}
 }
 
 @media (max-width: 499px) {
-	article.rapido > header > h1,
-	.rapido article > header > h1 {
+	.rapido > header > h1 {
 		font-size: 30px;
 		line-height: 45px;
 	}
 }
 
-article.rapido > header > p,
-.rapido article > header > p {
+.rapido > header > p {
 	font-size: 30px;
 	line-height: 45px;
 	max-width: 100%;
 }
 
-article.rapido > header > address,
-.rapido article > header > address {
+.rapido > header > address {
 	font-style: normal;
 	font-size: 18px;
 	line-height: 30px;
@@ -403,42 +377,26 @@ article.rapido > header > address,
 	align-items: center;
 }
 
-article.rapido > header > address > a,
-.rapido article > header > address > a {
+.rapido > header > address > a {
 	margin: 5px 15px 5px 0;
 }
 
-.rapido main > header > img {
-	position: absolute;
-	left: 10px;
-	top: 15px;
-	height: 40px;
-	width: auto;
-}
-
-article.rapido > header > img,
-.rapido article > header > img,
-article.rapido > header > video,
-.rapido article > header > video {
+.rapido > header > img,
+.rapido > header > video {
 	margin: 20px 0 20px 0;
 }
 
-article.rapido > header > img,
-.rapido article > header > img,
-article.rapido > header > video,
-.rapido article > header > video,
-article.rapido > header > figure > img,
-.rapido article > header > figure > img,
-article.rapido > header > figure > video,
-.rapido article > header > figure > video {
+.rapido > header > img,
+.rapido > header > video,
+.rapido > header > figure > img,
+.rapido > header > figure > video {
 	width: 100%;
 	display: block;
 	box-shadow: 0 0 15px -5px rgba(0, 0, 0, 0.23);
 	border-radius: 3px;
 }
 
-article.rapido > header > address > img,
-.rapido article > header > address > img {
+.rapido > header > address > img {
 	vertical-align: middle;
 	border-radius: 25px;
 	width: 50px;
@@ -446,196 +404,37 @@ article.rapido > header > address > img,
 	margin-right: 5px;
 }
 
-article.rapido > header > figure > figcaption,
-.rapido article > header > figure > figcaption {
+.rapido > header > figure > figcaption {
 	width: 100%;
 	margin: 5px 0 0 0;
 }
 
-article.rapido ul,
-.rapido article ul,
-article.rapido ol,
-.rapido article ol {
+.rapido ul,
+.rapido ol {
 	max-width: 600px;
 	width: 100%;
 	list-style-position: inside;
 	margin: 0 0 20px 0;
 }
 
-article.rapido ul,
-.rapido article ul {
+.rapido ul {
 	list-style-type: disc;
 }
 
-article.rapido ol,
-.rapido article ol {
+.rapido ol {
 	list-style-type: decimal;
 }
 
-article.rapido li,
-.rapido article li {
+.rapido li {
 	font-size: 14px;
 	line-height: 21px;
 }
 
-article.rapido li > p,
-.rapido article li > p,
-article.rapido > header > figure > figcaption > p,
-.rapido article > header > figure > figcaption > p {
+.rapido li > p,
+.rapido > header > figure > figcaption > p {
 	font-size: 14px;
 	line-height: 21px;
 	display: inline;
-}
-
-.rapido main > header {
-	width: 100%;
-	min-height: 70px;
-	margin: 0;
-	padding: 0;
-}
-
-.rapido main > header > nav {
-	display: none;
-	position: relative;
-	overflow-x: hidden;
-	overflow-y: auto;
-}
-
-.rapido main > header > nav a {
-	display: flex;
-	position: relative;
-}
-
-.rapido main > header > button {
-	display: none;
-	height: 70px;
-	width: 100%;
-	text-align: right;
-	background: #fff;
-	border: 0;
-	min-height: 70px;
-	border-bottom: 1px solid #ededed;
-}
-
-.rapido main > header > button > a {
-	font-size: 30px;
-	text-decoration: none;
-	color: inherit;
-	padding: 0 25px;
-}
-
-.rapido main > header > nav + button {
-	text-align: center;
-	border-bottom: 2px solid #353839;
-}
-
-.rapido main > header > nav + button > a {
-	font-size: 16px;
-	text-decoration: none;
-	color: inherit;
-	opacity: 0.5;
-}
-
-.rapido main > header > button:first-child {
-	text-align: right;
-}
-
-.rapido main > header > nav > ul {
-	display: block;
-	position: relative;
-	list-style-type: none;
-	margin: 0;
-	padding: 0;
-}
-
-.rapido main > header > nav > ul > li {
-	border-bottom: 1px solid #ededed;
-	min-height: 70px;
-	display: flex;
-	align-items: center;
-	justify-content: flex-start;
-	padding: 0 20px;
-}
-
-.rapido main > header > nav > ul > li > a {
-	display: flex;
-	align-items: center;
-	text-decoration: none;
-	font-weight: bold;
-	font-size: 16px;
-	color: #353839;
-	height: 100%;
-	width: 100%;
-}
-
-.rapido main > header > nav > ul > li > a > img {
-	width: 30px;
-	margin: 0 0 0 10px;
-	vertical-align: middle;
-}
-
-@media only screen and (min-width: 1024px) {
-	.rapido main > header {
-		min-height: 90px;
-		border-bottom: 1px solid #ededed;
-		display: flex;
-		align-items: center;
-		justify-content: flex-end;
-	}
-
-	.rapido main > header > img {
-		top: unset;
-		left: 40px;
-	}
-
-	.rapido main > header > nav {
-		display: block;
-		position: relative;
-		overflow: visible;
-	}
-
-	.rapido main > header > nav > ul {
-		min-height: 0;
-	}
-
-	.rapido main > header > nav > ul > li {
-		display: inline-block;
-		border-bottom: 0;
-		min-height: 0;
-		padding: 0 40px 0 0;
-	}
-}
-
-/* hint from https://github.com/codezero-be/responsive-nav */
-@media only screen and (max-width: 1023px) {
-	.rapido main > header > button:first-child {
-		display: block;
-	}
-
-	.rapido main > header > nav:hover + button,
-	.rapido main > header > nav:hover,
-	.rapido main > header > button:first-child:hover + nav,
-	.rapido main > header > button:first-child:hover + nav + button {
-		display: block;
-	}
-}
-
-.rapido main > footer:last-child {
-	width: 100%;
-	height: 50px;
-	border-top: 1px solid #ededed;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-}
-
-.rapido main > footer:last-child p,
-.rapido main > footer:last-child small {
-	font-family: "Consolas", "Courier", monospace;
-	margin: 0;
-	font-size: 12px;
-	line-height: 18px;
-	text-align: center;
 }
 
 .rapido .katex-display {

--- a/rapido.css
+++ b/rapido.css
@@ -1,20 +1,38 @@
+/* all elements */
+
 .rapido * {
 	box-sizing: border-box;
 	padding: 0;
 	margin: 0;
 }
 
+/* end all elements */
+
+/* address */
+
+article.rapido > header > address {
+	display: block;
+	margin-bottom: 20px;
+	font-style: normal;
+	font-size: 18px;
+	line-height: 30px;
+}
+
+/* end address */
+
+/* article */
+
 article.rapido {
+	width: 1024px;
+	max-width: 100%;
 	box-sizing: border-box;
+	margin: auto;
+	padding: 0 40px;
 	font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	-webkit-text-size-adjust: 100%;
 	color: #353839;
-	width: 1024px;
-	max-width: 100%;
-	margin: auto;
-	padding: 0 40px;
 }
 
 @media (max-width: 1023px) {
@@ -24,88 +42,118 @@ article.rapido {
 	}
 }
 
-.rapido a {
-	color: inherit;
-	text-decoration: underline;
+/* end article */
+
+/* aside */
+
+.rapido section > aside {
+	width: 100%;
+	max-width: 600px;
+	border-top: 2px solid #353839;
+	border-bottom: 2px solid #353839;
+	margin: 0 0 20px 0;
+	padding-top: 20px;
 }
+
+/* end aside */
+
+/* header */
+
+article.rapido > header {
+	width: 100%;
+	margin: 50px 0;
+}
+
+@media (max-width: 1023px) {
+	article.rapido > header {
+		margin: 30px 0;
+	}
+}
+
+/* end header */
+
+/* h1 */
+
+.rapido section > h1 {
+	width: 100%;
+	max-width: 600px;
+	margin: 0 0 30px 0;
+	font-size: 30px;
+	line-height: 45px;
+	font-weight: bold;
+}
+
+article.rapido > header > h1 {
+	margin: 0 0 50px 0;
+	font-size: 60px;
+	line-height: 80px;
+	font-weight: bold;
+}
+
+.rapido section figcaption > h1,
+article.rapido > header > figure > figcaption > h1 {
+	display: inline;
+	padding: 0;
+	font-size: 14px;
+	line-height: 21px;
+	font-weight: bold;
+}
+
+@media (max-width: 1023px) {
+	article.rapido > header > h1 {
+		font-size: 40px;
+		line-height: 60px;
+	}
+}
+
+@media (max-width: 499px) {
+	article.rapido > header > h1 {
+		font-size: 30px;
+		line-height: 45px;
+	}
+}
+
+/* end h1 */
+
+/* h2 */
+
+.rapido section > h2 {
+	width: 100%;
+	max-width: 600px;
+	margin: 0 0 20px 0;
+	font-size: 20px;
+	line-height: 30px;
+	font-weight: bold;
+}
+
+/* end h2 */
+
+/* section */
 
 .rapido section {
 	width: 100%;
 	padding: 10px 0;
 }
 
-.rapido section > h1 {
-	font-size: 30px;
-	line-height: 45px;
+/* end section */
+
+/* blockquote */
+
+.rapido section > blockquote {
 	width: 100%;
 	max-width: 600px;
-	font-weight: bold;
-	margin: 0 0 30px 0;
+	padding: 20px 40px 0 40px;
 }
 
-.rapido section > h2 {
-	font-size: 20px;
-	line-height: 30px;
-	font-weight: bold;
-	width: 100%;
-	max-width: 600px;
-	margin: 0 0 20px 0;
+@media (max-width: 380px) {
+	.rapido section > blockquote {
+		padding: 20px 20px 0 20px;
+	}
 }
 
-.rapido p,
-.rapido section p {
-	font-size: 18px;
-	line-height: 30px;
-	max-width: 600px;
-	margin: 0 0 20px 0;
-	position: relative;
-}
+/* end blockquote */
 
-.rapido span,
-.rapido var {
-	font-size: inherit;
-	line-height: inherit;
-}
-
-.rapido code {
-	font-family: "Consolas", "Courier", monospace;
-	font-size: inherit;
-	line-height: inherit;
-	color: blue;
-}
-
-.rapido pre > code {
-	padding: 0 10px;
-	display: inline-block;
-}
-
-.rapido mark {
-	background: rgba(0, 0, 255, 0.1);
-	color: inherit;
-}
-
-.rapido pre > mark {
-	background: none;
-}
-
-.rapido pre > mark > code {
-	display: inline-block;
-	padding: 0 8px;
-	min-width: 100%;
-	background: rgba(0, 0, 255, 0.05);
-	border-left: 2px solid blue;
-}
-
-.rapido strong {
-	font-style: normal;
-	font-weight: bold;
-}
-
-.rapido q,
-.rapido em {
-	font-style: italic;
-	font-weight: normal;
-}
+/* div */
 
 .rapido div {
 	width: 100%;
@@ -114,57 +162,95 @@ article.rapido {
 	overflow-x: auto;
 }
 
-.rapido p > img {
-	vertical-align: middle;
-}
-
-.rapido pre {
-	font-family: "Consolas", "Courier", monospace;
-	background:
-		repeating-linear-gradient(
-			-45deg,
-			#f5f5f5,
-			#f5f5f5 3px,
-			#f7f7f7 3px,
-			#f7f7f7 6px
-		);
-	font-size: 14px;
-	line-height: 21px;
+.rapido section figure > div {
 	width: 600px;
 	max-width: 100%;
-	padding: 5px 0;
 	overflow-y: hidden;
 	overflow-x: auto;
-	border-radius: 2px;
 }
 
-.rapido section > aside {
-	max-width: 600px;
-	width: 100%;
-	border-top: 2px solid #353839;
-	border-bottom: 2px solid #353839;
-	padding-top: 20px;
-	margin: 0 0 20px 0;
+/* end div */
+
+/* figcaption */
+
+.rapido section figcaption {
+	width: 324px;
+	margin-left: 20px;
 }
 
-.rapido section > aside > p {
-	font-size: 30px;
-	line-height: 45px;
-	max-width: 600px;
-	margin: 0 0 20px 0;
-	position: relative;
-}
-
-.rapido section > blockquote {
-	max-width: 600px;
-	width: 100%;
-	padding: 20px 40px 0 40px;
-}
-
-@media (max-width: 380px) {
-	.rapido section > blockquote {
-		padding: 20px 20px 0 20px;
+@media (max-width: 1023px) {
+	.rapido section figcaption {
+		width: 600px;
+		margin: 5px 0 0 0;
 	}
+}
+
+article.rapido > header > figure > figcaption {
+	width: 100%;
+	margin: 5px 0 0 0;
+}
+
+/* end figcaption */
+
+/* figure */
+
+.rapido figure {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: flex-start;
+	margin: 20px 0 20px 0;
+}
+
+/* end figure */
+
+/* li */
+
+.rapido li {
+	font-size: 14px;
+	line-height: 21px;
+}
+
+/* end li */
+
+/* ol, ul */
+
+.rapido ol,
+.rapido ul {
+	width: 100%;
+	max-width: 600px;
+	margin: 0 0 20px 0;
+	list-style-position: inside;
+}
+
+.rapido ul {
+	list-style-type: disc;
+}
+
+.rapido ol {
+	list-style-type: decimal;
+}
+
+/* end ol, ul */
+
+/* p */
+
+.rapido p,
+.rapido section p {
+	position: relative;
+	max-width: 600px;
+	margin: 0 0 20px 0;
+	font-size: 18px;
+	line-height: 30px;
+}
+
+.rapido li > p {
+	display: inline;
+	font-size: 14px;
+	line-height: 21px;
+}
+
+.rapido section figure > p {
+	width: 600px;
 }
 
 .rapido section > blockquote > p {
@@ -180,44 +266,192 @@ article.rapido {
 	content: '”';
 }
 
+.rapido section figcaption > p {
+	display: inline;
+	font-size: 14px;
+	line-height: 21px;
+}
+
+article.rapido > header > p {
+	max-width: 100%;
+	font-size: 30px;
+	line-height: 45px;
+}
+
+.rapido section > aside > p {
+	position: relative;
+	max-width: 600px;
+	margin: 0 0 20px 0;
+	font-size: 30px;
+	line-height: 45px;
+}
+
+.rapido > header > figure > figcaption > p {
+	display: inline;
+	font-size: 14px;
+	line-height: 21px;
+}
+
+/* end p */
+
+/* pre */
+
+.rapido pre {
+	width: 600px;
+	max-width: 100%;
+	padding: 5px 0;
+	overflow-y: hidden;
+	overflow-x: auto;
+	border-radius: 2px;
+	font-family: "Consolas", "Courier", monospace;
+	background:
+		repeating-linear-gradient(
+			-45deg,
+			#f5f5f5,
+			#f5f5f5 3px,
+			#f7f7f7 3px,
+			#f7f7f7 6px
+		);
+	font-size: 14px;
+	line-height: 21px;
+}
+
+/* end pre */
+
+/* a */
+
+.rapido a {
+	font-size: inherit;
+	line-height: inherit;
+	color: inherit;
+	text-decoration: underline;
+}
+
+article.rapido > header > address > a {
+	margin: 5px 15px 5px 0;
+}
+
+/* end a */
+
+/* cite */
+
 .rapido section > cite {
 	display: block;
-	text-align: right;
-	font-size: 16px;
-	line-height: 24px;
 	width: 100%;
 	max-width: 600px;
 	margin: 0 0 20px 0;
+	text-align: right;
+	font-size: 16px;
+	line-height: 24px;
 }
 
 .rapido section > cite::before {
 	content: "– ";
 }
 
-.rapido figure {
-	margin: 20px 0 20px 0;
-	display: flex;
-	align-items: flex-start;
-	flex-wrap: wrap;
+/* end cite */
+
+/* code */
+
+.rapido code {
+	font-family: "Consolas", "Courier", monospace;
+	font-size: inherit;
+	line-height: inherit;
+	color: blue;
 }
 
-.rapido figcaption {
+.rapido pre > code {
+	display: inline-block;
+	padding: 0 10px;
+}
+
+.rapido pre > mark > code {
+	display: inline-block;
+	min-width: 100%;
+	padding: 0 8px;
+	border-left: 2px solid blue;
+	background: rgba(0, 0, 255, 0.05);
+}
+
+/* end code */
+
+/* mark */
+
+.rapido mark {
+	background: rgba(0, 0, 255, 0.1);
+	color: inherit;
+}
+
+.rapido pre > mark {
+	background: none;
+}
+
+/* end mark */
+
+/* small */
+
+.rapido small {
+	position: absolute;
 	width: 324px;
-	margin-left: 20px;
+	padding: 3px 0 0 0;
+	top: 0;
+	right: calc(-324px - 20px);
+	float: right;
+	font-size: 14px;
+	line-height: 21px;
 }
 
 @media (max-width: 1023px) {
-	.rapido figcaption {
-		width: 600px;
-		margin: 5px 0 0 0;
+	.rapido small {
+		display: block;
+		position: relative;
+		width: 100%;
+		right: 0;
+		float: none;
+		margin: 20px 0;
+		padding: 0;
 	}
 }
 
-.rapido figure > div {
-	width: 600px;
+@media (min-width: 601px) and (max-width: 1023px) {
+	.rapido small {
+		overflow: auto;
+	}
+}
+
+/* end small */
+
+/* inline elements */
+
+.rapido strong {
+	font-style: normal;
+	font-weight: bold;
+}
+
+.rapido q,
+.rapido em {
+	font-style: italic;
+	font-weight: normal;
+}
+
+/* end inline elements */
+
+/* img, video */
+
+.rapido p > img {
+	vertical-align: middle;
+}
+
+.rapido small > img {
 	max-width: 100%;
-	overflow-y: hidden;
-	overflow-x: auto;
+	padding-top: 5px;
+}
+
+@media (min-width: 601px) and (max-width: 1023px) {
+	.rapido small > img {
+		max-width: 324px;
+		float: right;
+	}
 }
 
 .rapido section figure > img,
@@ -225,32 +459,49 @@ article.rapido {
 	display: block;
 	flex: 0 0 auto;
 	width: 600px;
+	max-width: 100%;
 	height: auto;
 	box-shadow: 0 0 15px -5px rgba(0, 0, 0, 0.23);
 	border-radius: 3px;
-	max-width: 100%;
 }
 
-.rapido section figure > p {
-	width: 600px;
+article.rapido > header > img,
+article.rapido > header > video {
+	margin: 20px 0 20px 0;
 }
 
-.rapido section figcaption > p {
-	display: inline;
-	font-size: 14px;
-	line-height: 21px;
+article.rapido > header > img,
+article.rapido > header > video,
+article.rapido > header > figure > img,
+article.rapido > header > figure > video {
+	display: block;
+	width: 100%;
+	border-radius: 3px;
+	box-shadow: 0 0 15px -5px rgba(0, 0, 0, 0.23);
 }
+
+article.rapido > header > address > img {
+	width: 50px;
+	height: 50px;
+	margin-right: 5px;
+	vertical-align: middle;
+	border-radius: 25px;
+}
+
+/* end img, video */
+
+/* table */
 
 .rapido table {
 	min-width: 600px;
 	padding: 10px;
+	border-collapse: collapse;
+	border-top: 1px solid #ededed;
+	border-left: 1px solid #ededed;
 	text-align: left;
 	font-family: inherit;
 	font-size: 14px;
 	line-height: 21px;
-	border-collapse: collapse;
-	border-top: 1px solid #ededed;
-	border-left: 1px solid #ededed;
 }
 
 .rapido table thead {
@@ -276,167 +527,12 @@ article.rapido {
 	border-right: 1px solid #ededed;
 }
 
-.rapido small {
-	font-size: 14px;
-	line-height: 21px;
-	width: 324px;
-	float: right;
-	padding: 3px 0 0 0;
-	position: absolute;
-	right: calc(-324px - 20px);
-	top: 0;
-}
+/* end table */
 
-@media (max-width: 1023px) {
-	.rapido small {
-		width: 100%;
-		float: none;
-		padding: 0;
-		margin: 20px 0;
-		position: relative;
-		right: 0;
-		display: block;
-	}
-}
-
-.rapido small > p {
-	font-size: 14px;
-	line-height: 21px;
-}
-
-.rapido small > img {
-	padding-top: 5px;
-	max-width: 100%;
-}
-
-.rapido > header {
-	width: 100%;
-	margin: 50px 0;
-}
-
-@media (min-width: 601px) and (max-width: 1023px) {
-	.rapido small {
-		overflow: auto;
-	}
-
-	.rapido small > img {
-		max-width: 324px;
-		float: right;
-	}
-}
-
-@media (max-width: 1023px) {
-	.rapido > header {
-		margin: 30px 0;
-	}
-}
-
-.rapido > header > h1 {
-	font-size: 60px;
-	line-height: 80px;
-	font-weight: bold;
-	margin: 0 0 50px 0;
-}
-
-.rapido section figcaption > h1,
-.rapido > header > figure > figcaption > h1 {
-	display: inline;
-	font-size: 14px;
-	font-weight: bold;
-	line-height: 21px;
-	padding: 0;
-}
-
-@media (max-width: 1023px) {
-	.rapido > header > h1 {
-		font-size: 40px;
-		line-height: 60px;
-	}
-}
-
-@media (max-width: 499px) {
-	.rapido > header > h1 {
-		font-size: 30px;
-		line-height: 45px;
-	}
-}
-
-.rapido > header > p {
-	font-size: 30px;
-	line-height: 45px;
-	max-width: 100%;
-}
-
-.rapido > header > address {
-	font-style: normal;
-	font-size: 18px;
-	line-height: 30px;
-	margin-bottom: 20px;
-	display: block;
-	flex-wrap: wrap;
-	align-items: center;
-}
-
-.rapido > header > address > a {
-	margin: 5px 15px 5px 0;
-}
-
-.rapido > header > img,
-.rapido > header > video {
-	margin: 20px 0 20px 0;
-}
-
-.rapido > header > img,
-.rapido > header > video,
-.rapido > header > figure > img,
-.rapido > header > figure > video {
-	width: 100%;
-	display: block;
-	box-shadow: 0 0 15px -5px rgba(0, 0, 0, 0.23);
-	border-radius: 3px;
-}
-
-.rapido > header > address > img {
-	vertical-align: middle;
-	border-radius: 25px;
-	width: 50px;
-	height: 50px;
-	margin-right: 5px;
-}
-
-.rapido > header > figure > figcaption {
-	width: 100%;
-	margin: 5px 0 0 0;
-}
-
-.rapido ul,
-.rapido ol {
-	max-width: 600px;
-	width: 100%;
-	list-style-position: inside;
-	margin: 0 0 20px 0;
-}
-
-.rapido ul {
-	list-style-type: disc;
-}
-
-.rapido ol {
-	list-style-type: decimal;
-}
-
-.rapido li {
-	font-size: 14px;
-	line-height: 21px;
-}
-
-.rapido li > p,
-.rapido > header > figure > figcaption > p {
-	font-size: 14px;
-	line-height: 21px;
-	display: inline;
-}
+/* KaTex */
 
 .rapido .katex-display {
 	padding: 10px 0 !important;
 }
+
+/* end KaTex */

--- a/rapido.css
+++ b/rapido.css
@@ -14,7 +14,14 @@ body.rapido {
 	padding: 0;
 }
 
+article.rapido,
 .rapido article {
+	box-sizing: border-box;
+	font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	-webkit-text-size-adjust: 100%;
+	color: #353839;
 	width: 1024px;
 	max-width: 100%;
 	margin: auto;
@@ -22,6 +29,7 @@ body.rapido {
 }
 
 @media (max-width: 1023px) {
+	article.rapido,
 	.rapido article {
 		width: 600px;
 		padding: 0 20px 0 20px;
@@ -280,6 +288,7 @@ body.rapido {
 	border-right: 1px solid #ededed;
 }
 
+article.rapido small,
 .rapido article small {
 	font-size: 14px;
 	line-height: 21px;
@@ -292,6 +301,7 @@ body.rapido {
 }
 
 @media (max-width: 1023px) {
+	article.rapido small,
 	.rapido article small {
 		width: 100%;
 		float: none;
@@ -303,26 +313,31 @@ body.rapido {
 	}
 }
 
+article.rapido small > p,
 .rapido article small > p {
 	font-size: 14px;
 	line-height: 21px;
 }
 
+article.rapido small > img,
 .rapido article small > img {
 	padding-top: 5px;
 	max-width: 100%;
 }
 
+article.rapido > header,
 .rapido article > header {
 	width: 100%;
 	margin: 50px 0;
 }
 
 @media (min-width: 601px) and (max-width: 1023px) {
+	article.rapido small,
 	.rapido article small {
 		overflow: auto;
 	}
 
+	article.rapido small > img,
 	.rapido article small > img {
 		max-width: 324px;
 		float: right;
@@ -330,11 +345,13 @@ body.rapido {
 }
 
 @media (max-width: 1023px) {
+	article.rapido > header,
 	.rapido article > header {
 		margin: 30px 0;
 	}
 }
 
+article.rapido > header > h1,
 .rapido article > header > h1 {
 	font-size: 60px;
 	line-height: 80px;
@@ -343,6 +360,7 @@ body.rapido {
 }
 
 .rapido section figcaption > h1,
+article.rapido > header > figure > figcaption > h1,
 .rapido article > header > figure > figcaption > h1 {
 	display: inline;
 	font-size: 14px;
@@ -351,12 +369,8 @@ body.rapido {
 	padding: 0;
 }
 
-.rapido section figcaption > h1::after,
-.rapido article > header > figure > figcaption > h1::after {
-	content: '.';
-}
-
 @media (max-width: 1023px) {
+	article.rapido > header > h1,
 	.rapido article > header > h1 {
 		font-size: 40px;
 		line-height: 60px;
@@ -364,18 +378,21 @@ body.rapido {
 }
 
 @media (max-width: 499px) {
+	article.rapido > header > h1,
 	.rapido article > header > h1 {
 		font-size: 30px;
 		line-height: 45px;
 	}
 }
 
+article.rapido > header > p,
 .rapido article > header > p {
 	font-size: 30px;
 	line-height: 45px;
 	max-width: 100%;
 }
 
+article.rapido > header > address,
 .rapido article > header > address {
 	font-style: normal;
 	font-size: 18px;
@@ -386,6 +403,7 @@ body.rapido {
 	align-items: center;
 }
 
+article.rapido > header > address > a,
 .rapido article > header > address > a {
 	margin: 5px 15px 5px 0;
 }
@@ -398,14 +416,20 @@ body.rapido {
 	width: auto;
 }
 
+article.rapido > header > img,
 .rapido article > header > img,
+article.rapido > header > video,
 .rapido article > header > video {
 	margin: 20px 0 20px 0;
 }
 
+article.rapido > header > img,
 .rapido article > header > img,
+article.rapido > header > video,
 .rapido article > header > video,
+article.rapido > header > figure > img,
 .rapido article > header > figure > img,
+article.rapido > header > figure > video,
 .rapido article > header > figure > video {
 	width: 100%;
 	display: block;
@@ -413,6 +437,7 @@ body.rapido {
 	border-radius: 3px;
 }
 
+article.rapido > header > address > img,
 .rapido article > header > address > img {
 	vertical-align: middle;
 	border-radius: 25px;
@@ -421,12 +446,15 @@ body.rapido {
 	margin-right: 5px;
 }
 
+article.rapido > header > figure > figcaption,
 .rapido article > header > figure > figcaption {
 	width: 100%;
 	margin: 5px 0 0 0;
 }
 
+article.rapido ul,
 .rapido article ul,
+article.rapido ol,
 .rapido article ol {
 	max-width: 600px;
 	width: 100%;
@@ -434,20 +462,25 @@ body.rapido {
 	margin: 0 0 20px 0;
 }
 
+article.rapido ul,
 .rapido article ul {
 	list-style-type: disc;
 }
 
+article.rapido ol,
 .rapido article ol {
 	list-style-type: decimal;
 }
 
+article.rapido li,
 .rapido article li {
 	font-size: 14px;
 	line-height: 21px;
 }
 
+article.rapido li > p,
 .rapido article li > p,
+article.rapido > header > figure > figcaption > p,
 .rapido article > header > figure > figcaption > p {
 	font-size: 14px;
 	line-height: 21px;
@@ -605,6 +638,6 @@ body.rapido {
 	text-align: center;
 }
 
-.katex-display {
+.rapido .katex-display {
 	padding: 10px 0 !important;
 }


### PR DESCRIPTION
This PR adds 3 commits:

*  **text review**: the most important commit, actually I did my best to fix typos and to reorganise sentences. Please have a read (open `index.html` in a browser) and tell me if any sentence sounds weird, thanks.
* **document header and footer are out of scope**: I removed header and footer from the document, from the documentation and the stylesheet. This happened because I needed to clarify what Rapido is and what it is not. Rapido is meant for essays, like blog posts and technical or scientific articles. As a rule of thumb, Rapido should cover only what is necessary for an [article](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article). Rapido is not meant to create websites, so anything that is outside the `<article>` element is out of scope. The idea behind the documentation is to show what Rapido offers, so header and footer have been removed.
* **organise CSS code**: this commit only reorganizes the CSS code, now it should be a bit more maintainable.