### PR TITLE
close #127 | Point to a specific version of Rapido in the documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,11 +60,14 @@
         </section>
         <section>
           <h1 id="getting-started">Getting started</h1>
-          <p>Rapido provides style rules in the <code>rapido.css</code> stylesheet, you can download the CSS file from <a href="https://raw.githubusercontent.com/nextbitlabs/Rapido/master/rapido.css">Github</a> and link to it within the <code>&lt;head&gt;</code> element in your document.</p>
+          <p>Rapido provides style rules in the <code>rapido.css</code> stylesheet, you can see the latest version of the CSS file in <a href="https://raw.githubusercontent.com/nextbitlabs/Rapido/master/rapido.css">Github</a>. Use <code>rapido.css</code> linking to it within the <code>&lt;head&gt;</code> element in your document.</p>
           <figure>
             <pre><code>&lt;head&gt;</code>
-<mark><code>  &lt;link href="https://unpkg.com/@nextbitlabs/rapido@latest/rapido.css" rel="stylesheet" type="text/css"&gt;</code></mark>
+<mark><code>  &lt;link href="https://unpkg.com/@nextbitlabs/rapido@^3/rapido.css" rel="stylesheet" type="text/css"&gt;</code></mark>
 <code>&lt;/head&gt;</code></pre>
+            <figcaption>
+              <p>Link to <code>rapido.css</code> in <a href="https://unpkg.com/">unpkg</a>. Rapido uses <a href="https://semver.org/"></a> semantic versioning, the example fetches the major release 3.x.</p>
+            </figcaption>
           </figure>
           <p>The style rules defined in <code>rapido.css</code> are name-spaced under the CSS class <code>rapido</code>. Being Rapido thought for web essays, the place to use the CSS class is the <code>&lt;article&gt;</code> element, as showed in the next snippet.</p>
           <figure>
@@ -86,7 +89,7 @@
   &lt;head&gt;
     &lt;meta charset="utf-8"&gt;
     &lt;meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=yes"&gt;
-    &lt;link href="https://unpkg.com/@nextbitlabs/rapido@latest/rapido.css" rel="stylesheet" type="text/css"&gt;
+    &lt;link href="https://unpkg.com/@nextbitlabs/rapido@^3/rapido.css" rel="stylesheet" type="text/css"&gt;
   &lt;/head&gt;
   &lt;body&gt;
     &lt;main&gt;

--- a/index.html
+++ b/index.html
@@ -81,6 +81,11 @@
               <p>Rapido can be used in a web document created from scratch or within an existing document, the CSS class <code>rapido</code> makes Rapido not invasive with respect to existing CSS code.</p>
             </figcaption>
           </figure>
+          <h2>Install with npm</h2>
+          <p>Alternatively, you may want to install Rapido using <a href="https://www.npmjs.com/">npm</a>. This is especially useful when you want to add Rapido as a dependency of your application.</p>
+          <pre>
+<code>npm install @nextbitlabs/rapido</code>
+</pre>
           <h2>Get your hands dirty</h2>
           <p>If you want to try Rapido then you  need the skeleton of an HTML document. The next code snippet provides a minimal template, copy the snippet in a fresh HTML file.</p>
           <figure>


### PR DESCRIPTION
The scope of this PR is to point to a specific version in the documentation, this prevents to introduce breaking changes of major releases. Users should switch to a new major release carefully, reading [release notes](https://github.com/nextbitlabs/Rapido/releases) and looking at the final result on their published documents.

In the docs, I used the [semver range](https://docs.npmjs.com/misc/semver) `https://unpkg.com/@nextbitlabs/rapido@^3/rapido.css` for targeting versions >=3.0.0 <4.0.0.

Moreover, I mentioned how to install Rapido with npm.