### PR TITLE
close #128 | mention why CSS classes are out of scope

### DIFF
--- a/index.html
+++ b/index.html
@@ -535,7 +535,7 @@
 
         <section>
           <h1 id="customisations">Customisations</h1>
-          <p>Rapido focuses on semantic HTML, providing a default style for a variety of HTML elements. Being CSS classes out of scope, authors looking for a different style must opt for a customisation.</p>
+          <p>Rapido focuses on semantic HTML, providing a default style for a variety of HTML elements. Being CSS classes out of scope, authors looking for a different style must opt for a customisation.<small>Rapido does not expose CSS classes. This design choice makes Rapido easier to use and, due to how <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity#How_is_specificity_calculated">specificity</a> works, easier to extend with custom CSS classes.</small></p>
           <p>You may change the default CSS rules or write new rules that have precedence over the default ones. As usual, this is possible both with <strong>inline declarations</strong> and <strong>stylesheets</strong>. The following examples show some common customisations.
           </p>
           <figure>


### PR DESCRIPTION
I just want to mention that the design choice of not having CSS classes makes Rapido easier to customise with custom CSS classes.

For example, the style declaration `.rapido .section .figure p` has an higher [specificity](https://specificity.keegan.st/) than the declation `.rapido p.customClass`. On the contrary, the style declaration `.rapido section figure p` has an lower specificity than `.rapido p.customClass` and the latter override the former.
